### PR TITLE
Add Missing Dependency on cl-test-more

### DIFF
--- a/cl-project.asd
+++ b/cl-project.asd
@@ -28,7 +28,8 @@
                :cl-annot
                :cl-syntax
                :cl-syntax-annot
-               :local-time)
+               :local-time
+               :cl-test-more)
   :components ((:module "src"
                 :components
                 ((:file "cl-project"))))


### PR DESCRIPTION
When using this library as part of caveman, the function `(caveman.skeleton:generate)` uses cl-project, which in turn tests the creation of the directory with the project files using the `cl-test-more` library.  If this is not installed as a dependency, `cl-project` cannot properly the directory and the required files.

```
* (caveman.skeleton:generate #p"~/test")
writing ~/test/.gitignore
writing ~/test/README.markdown
writing ~/test/README.org
writing ~/test/test-test.asd
writing ~/test/test.asd
writing ~/test/src/test.lisp
writing ~/test/t/test.lisp

debugger invoked on a MISSING-COMPONENT in thread
#<THREAD "main thread" RUNNING {1002978CB3}>:
  Component "cl-test-more" not found

Type HELP for debugger help, or (SB-EXT:QUIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [REINITIALIZE-SOURCE-REGISTRY-AND-RETRY] Retry finding system cl-test-more
                                              after reinitializing the
                                              source-registry.
  1: [RETRY                                 ] Retry EVAL of current toplevel form.
  2: [CONTINUE                              ] Ignore error and continue loading file "/home/al/test/test-test.asd".
  3: [ABORT                                 ] Abort loading file "/home/al/test/test-test.asd".
  4:                                          Exit debugger, returning to top
                                              level.

((LAMBDA () :IN FIND-SYSTEM))
0] 1
```

See [related issue for caveman](https://github.com/fukamachi/caveman/pull/26) for more info.
