### PR TITLE
Allow uppercase letters in package name

### DIFF
--- a/src/cl-project.lisp
+++ b/src/cl-project.lisp
@@ -84,7 +84,7 @@
                       :name (regex-replace-all
                              "skeleton"
                              (pathname-name source-path)
-                             (string-downcase (getf *skeleton-parameters* :name)))
+                             (getf *skeleton-parameters* :name))
                       :type (pathname-type source-path))))
     (copy-file-to-file source-path target-path)))
 


### PR DESCRIPTION
This is a fix for a bug reported on caveman: fukamachi/caveman#67 and reverts  https://github.com/fukamachi/cl-project/commit/94658fa58da21dba192caf6c11cef311f8038fb7

The problem is that you can start a new project with an uppercase letter, but when make-project [tries to load the asd file](https://github.com/fukamachi/cl-project/blob/master/src/cl-project.lisp#L49) it fails with file not found - since the project name is uppercase and the file anme is lowercase.

This change *allows* uppercase letters in a project name and thus file names (whether people should do that is another story).  The other option is to force everything to downcase, which is a bit more strict.