### PR TITLE
Fixed copying directories

### DIFF
--- a/src/cl-project.lisp
+++ b/src/cl-project.lisp
@@ -65,8 +65,8 @@
 (defun copy-directory (source-dir target-dir)
   "Copy a directory recursively."
   (ensure-directories-exist target-dir)
-  (loop for file in (uiop:directory-files source-dir)
-        do (copy-file-to-dir file target-dir))
+  (loop for file in (set-difference (uiop:directory-files source-dir) (uiop:subdirectories source-dir) :test #'equal)
+     do (copy-file-to-dir file target-dir))
   (loop for dir in (uiop:subdirectories source-dir)
         do (copy-directory
             dir
@@ -85,7 +85,7 @@
                       :name (regex-replace-all
                              "skeleton"
                              (pathname-name source-path)
-                             (string-downcase (getf *skeleton-parameters* :name)))
+                             (getf *skeleton-parameters* :name))
                       :type (pathname-type source-path))))
     (copy-file-to-file source-path target-path)))
 


### PR DESCRIPTION
Hello!
Your caveman2 is using your cl-project to copy skeleton project from Caveman to whatever directory I point to. However, I encountered a bug, which I fixed - you assumed that #'uiop:directory-files returns only files, and not directories(or so it seems, looking at the code). I've fixed the problem. There was also second one(already fixed, but not merged, as I noticed now after looking at pull request section) - you're downcasing filenames, which is wrong, because it will make asdf not work for non-lowercase files.

It's ready to merge, and the problem will be fixed(has been for me, at least).