### PR TITLE
Integrating a GNU autotools skeleton

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -65,6 +65,7 @@ All parameters are optional.
 * `:email`: Your e-mail address.
 * `:license`: License of the new project.
 * `:depends-on`: A list of dependencies.
+* `:application`: If non-nil the GNU autotools skeleton will be added too.
 
 ## Author
 

--- a/README.markdown
+++ b/README.markdown
@@ -49,7 +49,8 @@ quicklisp/asdf search path and you are good to go for a compilation by
 simply:
 ```sh
 sh autogen.sh
-./configure
+./configure # use the default installed Lisp
+./configure --with-lisp=ecl # use ECL for the compilation
 make check # runs asdf:test-system
 make # generates the executable
 ```
@@ -76,3 +77,8 @@ Copyright (c) 2011 Eitaro Fukamachi (e.arrows@gmail.com)
 ## License
 
 Licensed under the LLGPL License.
+
+All the application skeleton parts are taken from
+[stumpWM](https://github.com/stumpwm/stumpwm) which is licensed as
+GPLv2. Therefore if you use the skeleton files for an application you
+transform your project to GPLv2 too.

--- a/README.markdown
+++ b/README.markdown
@@ -24,15 +24,35 @@
 
 ### 1. Flexible templates
 
-CL-Project supports more parameters to embed, by using [CL-EMB](http://common-lisp.net/project/cl-emb/) to represent the skeleton files (See "cl-project/skeleton/").
+CL-Project supports more parameters to embed, by using
+[CL-EMB](http://common-lisp.net/project/cl-emb/) to represent the
+skeleton files (See "cl-project/skeleton/").
 
 ### 2. One package per file style (Modern)
 
-A modern CL project should be in accordance with [some rules](http://labs.ariel-networks.com/cl-style-guide.html). For instance, one file must have one package in it.
+A modern CL project should be in accordance with
+[some rules](http://labs.ariel-networks.com/cl-style-guide.html). For
+instance, one file must have one package in it.
 
 ### 3. Recommends unit testing
 
-Modern projects should have some unit tests. CL-Project generates a system for unit testing, so you can begin writing unit tests as soon as the project is generated.
+Modern projects should have some unit tests. CL-Project generates a
+system for unit testing, so you can begin writing unit tests as soon
+as the project is generated.
+
+### 4. Possbile integration with the GNU autotools
+
+It is possible to generate a Makefile with GNU autools which compiles
+your Application. Simply add :APPLICATION T to get those scripts
+included! Just make sure that the generated project lies on the
+quicklisp/asdf search path and you are good to go for a compilation by
+simply:
+```sh
+sh autogen.sh
+./configure
+make check # runs asdf:test-system
+make # generates the executable
+```
 
 ## Parameters
 

--- a/skeleton/Makefile.in
+++ b/skeleton/Makefile.in
@@ -1,0 +1,35 @@
+APPLICATION_NAME=<% @var name %>
+
+LISP=@LISP_PROGRAM@
+
+ecl_BUILDOPTS=-shell ./compile.lisp
+sbcl_BUILDOPTS=--load ./compile.lisp
+
+ecl_BUILDOPTS_RUN_TEST=-eval "(asdf:test-system :$(APPLICATION_NAME)-test)"
+sbcl_BUILDOPTS_RUN_TEST= --non-interactive --eval "(asdf:test-system :$(APPLICATION_NAME)-test)"
+
+datarootdir = @datarootdir@
+prefix=@prefix@
+exec_prefix= @exec_prefix@
+bindir=@bindir@
+
+FILES=$(APPLICATION_NAME).asd
+
+all: $(APPLICATION_NAME)
+
+$(APPLICATION_NAME): $(FILES)
+	$(LISP) $(@LISP@_BUILDOPTS)
+
+clean:
+	rm -f *.fasl *.fas *.lib *.*fsl
+	rm -f $(APPLICATION_NAME)
+
+check: all
+	$(LISP) $(@LISP@_BUILDOPTS_RUN_TEST)
+
+install: all
+	test -z "$(destdir)$(bindir)" || mkdir -p "$(destdir)$(bindir)"
+	install -m 755 $(APPLICATION_NAME) "$(destdir)$(bindir)"
+
+uninstall:
+	rm "$(destdir)$(bindir)/$(APPLICATION_NAME)"

--- a/skeleton/autogen.sh
+++ b/skeleton/autogen.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+autoreconf

--- a/skeleton/compile.lisp
+++ b/skeleton/compile.lisp
@@ -18,3 +18,7 @@
                  :epilogue-code '(progn
                                   (<% @var name %>:main (ext:command-args))))
 
+#+ccl
+(ccl:save-application "<% @var name %>"
+                      :prepend-kernel t
+                      :toplevel-function #'<% @var name %>:main)

--- a/skeleton/compile.lisp
+++ b/skeleton/compile.lisp
@@ -1,0 +1,20 @@
+(in-package #:cl-user)
+
+(load "<% @var name %>.asd")
+(asdf:oos 'asdf:load-op '<% @var name %>)
+
+#+sbcl
+(sb-ext:save-lisp-and-die "<% @var name %>"
+                          :compression t
+                          :toplevel (lambda () 
+                                      (<% @var name %>:main sb-ext:*posix-argv*)
+                                      0)
+                          :executable t)
+
+#+ecl
+(asdf:make-build '<% @var name %> :type :program :monolithic t
+                 :move-here "."
+                 :name-suffix ""
+                 :epilogue-code '(progn
+                                  (<% @var name %>:main (ext:command-args))))
+

--- a/skeleton/configure.ac
+++ b/skeleton/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT(<% @var name %>, 1.0, richard.baeck@free-your-pc.com)
+AC_INIT(<% @var name %>, 1.0, <% @var email %>)
 
 AC_SUBST(LISP_PROGRAM)
 AC_SUBST(LISP)

--- a/skeleton/configure.ac
+++ b/skeleton/configure.ac
@@ -1,0 +1,59 @@
+AC_PREREQ(2.59)
+AC_INIT(<% @var name %>, 1.0, richard.baeck@free-your-pc.com)
+
+AC_SUBST(LISP_PROGRAM)
+AC_SUBST(LISP)
+AC_SUBST(<% @var name %>_ASDF_DIR)
+
+# Checks for programs.
+AC_ARG_WITH(lisp,    [  --with-lisp=IMPL        use the specified lisp (sbcl, clisp, ccl or ecl)], LISP=$withval, LISP="any")
+AC_ARG_WITH(ecl,     [  --with-ecl=PATH         specify location of ecl], ECL_PATH=$withval, ECL_PATH="")
+AC_ARG_WITH(sbcl,    [  --with-sbcl=PATH        specify location of sbcl], SBCL_PATH=$withval, SBCL_PATH="")
+
+
+<% @var name %>_ASDF_DIR="`pwd`"
+
+if test -x "$ECL_PATH"; then
+   ECL=$ECL_PATH
+   AC_MSG_CHECKING([for ecl])
+   AC_MSG_RESULT($ECL)
+else
+   AC_PATH_PROG([ECL], ecl,"")
+fi
+
+if test -x "$SBCL_PATH"; then
+   SBCL=$SBCL_PATH
+   AC_MSG_CHECKING([for sbcl])
+   AC_MSG_RESULT($SBCL)
+else
+   AC_PATH_PROG([SBCL], sbcl,"")
+fi
+
+if test "x$LISP" = "xany"; then
+   if test "$SBCL"; then
+      LISP=sbcl
+   elif test "$ECL"; then
+      LISP=ecl
+   fi
+fi
+
+if test "x$LISP" = "xecl"; then
+   LISP_PROGRAM=$ECL
+elif test "x$LISP" = "xsbcl"; then
+   LISP_PROGRAM=$SBCL
+fi
+
+if test "x$LISP_PROGRAM" = "x"; then
+   AC_MSG_ERROR([*** No lisp is available.])
+fi
+
+AC_MSG_NOTICE([Using $LISP at $LISP_PROGRAM])
+
+# Checks for libraries.
+
+# Checks for header files.
+
+# Checks for typedefs, structures, and compiler characteristics.
+
+# Checks for library functions.
+AC_OUTPUT(Makefile)

--- a/skeleton/configure.ac
+++ b/skeleton/configure.ac
@@ -9,7 +9,7 @@ AC_SUBST(<% @var name %>_ASDF_DIR)
 AC_ARG_WITH(lisp,    [  --with-lisp=IMPL        use the specified lisp (sbcl, clisp, ccl or ecl)], LISP=$withval, LISP="any")
 AC_ARG_WITH(ecl,     [  --with-ecl=PATH         specify location of ecl], ECL_PATH=$withval, ECL_PATH="")
 AC_ARG_WITH(sbcl,    [  --with-sbcl=PATH        specify location of sbcl], SBCL_PATH=$withval, SBCL_PATH="")
-
+AC_ARG_WITH(ccl,     [  --with-ccl=PATH         specify location of ccl], CCL_PATH=$withval, CCL_PATH="")
 
 <% @var name %>_ASDF_DIR="`pwd`"
 
@@ -29,18 +29,30 @@ else
    AC_PATH_PROG([SBCL], sbcl,"")
 fi
 
+if test -x "$CCL_PATH"; then
+   CCL=$CCL_PATH
+   AC_MSG_CHECKING([for ccl])
+   AC_MSG_RESULT($CCL)
+else
+   AC_PATH_PROG([CCL],ccl,"")
+fi
+
 if test "x$LISP" = "xany"; then
    if test "$SBCL"; then
       LISP=sbcl
    elif test "$ECL"; then
       LISP=ecl
    fi
+   elif test "$CCL"; then
+      LISP=ccl
 fi
 
 if test "x$LISP" = "xecl"; then
    LISP_PROGRAM=$ECL
 elif test "x$LISP" = "xsbcl"; then
    LISP_PROGRAM=$SBCL
+elif test "x$LISP" = "xccl"; then
+   LISP_PROGRAM=$CCL
 fi
 
 if test "x$LISP_PROGRAM" = "x"; then

--- a/skeleton/src/skeleton.lisp
+++ b/skeleton/src/skeleton.lisp
@@ -1,6 +1,14 @@
 (in-package :cl-user)
 (defpackage <% @var name %>
-  (:use :cl))
+            (:use :cl)<% @if application %>(:export :main)<% @endif %>)
 (in-package :<% @var name %>)
 
-;; blah blah blah.
+
+<% @if application %>
+(defun main (args)
+  ;; Here will be your application
+  0 ;; return code
+  )
+<% @else %>
+;; Here will be your applicaton/library
+<% @endif %>

--- a/src/cl-project.lisp
+++ b/src/cl-project.lisp
@@ -13,7 +13,7 @@
            #:generate-skeleton))
 (in-package :cl-project)
 
-(defun make-project (path &rest params &key name description author email license depends-on (without-tests nil) &allow-other-keys)
+(defun make-project (path &rest params &key name description author email license depends-on application (without-tests nil) &allow-other-keys)
   "Generate a skeleton."
   (declare (ignore name description author email license depends-on without-tests))
   (check-type path pathname)

--- a/src/skeleton.lisp
+++ b/src/skeleton.lisp
@@ -37,9 +37,6 @@
            ;; Older ASDF/UIOP's uiop:directory-files returns also directories on Linux.
            ;; The bug had been fixed at ASDF 3.1.0.64 (https://bugs.launchpad.net/asdf/+bug/1276748), however, it's safe to filter directories anyway.
            ;; ref. https://github.com/fukamachi/cl-project/pull/17
-           (print (set-difference (uiop:directory-files path)
-                                  (uiop:subdirectories path)
-                                  :test #'equal))
            (remove-if #'(lambda (file)
                           (declare (pathname file))
                           (let ((is-application-file

--- a/src/specials.lisp
+++ b/src/specials.lisp
@@ -3,6 +3,7 @@
   (:use #:cl)
   (:export #:*default-skeleton-directory*
            #:*skeleton-directory*
+           #:*application-files*
            #:*skeleton-parameters*))
 (in-package :cl-project.specials)
 
@@ -11,5 +12,14 @@
 
 (defvar *skeleton-directory*
   *default-skeleton-directory*)
+
+(defparameter *default-application-files*
+  '("autogen.sh"
+    "configure.ac"
+    "Makefile.in"
+    "compile.lisp"))
+
+(defvar *application-files*
+  *default-application-files*)
 
 (defvar *skeleton-parameters* nil)


### PR DESCRIPTION
With this it is possible to create a Lisp application and install it just like a plain C/C++ GNU autotools project. It enables the developer to get the good of both worlds and to easy deliver full Lisp applications to the user via system wide package managers (like APT, zypper or yum).
