### PR TITLE
Apply 'pathname' to the first argument

### DIFF
--- a/roswell/make-project
+++ b/roswell/make-project
@@ -37,7 +37,7 @@ A command-line interface for cl-project:make-project.
     (let ((path (pop args)))
       (when (starts-with-subseq "--" path)
         (terminate "No path given."))
-      (cons path
+      (cons (pathname path)
             (loop for index from 0 below (length args)
                   for first = (elt args index)
                   for rest = (subseq args (incf index))


### PR DESCRIPTION
Using cl-project via roswell script in SBCL and CLISP, an type mismatch error occurs.
While `cl-project:make-project` requires a pathname value as the first argument, in the script, the first argument is of type string.

To fix it, the first argument (it is specified from command line arguments) should be applied `pathname` function and I added it.