### PR TITLE
Remove superfluous (check-type path pathname)

### DIFF
--- a/src/cl-project.lisp
+++ b/src/cl-project.lisp
@@ -16,7 +16,6 @@
 (defun make-project (path &rest params &key name description author email license depends-on (without-tests nil) &allow-other-keys)
   "Generate a skeleton."
   (declare (ignore name description author email license depends-on without-tests))
-  (check-type path pathname)
 
   ;; Ensure `path' ends with a slash(/).
   (setf path (uiop:ensure-directory-pathname path))


### PR DESCRIPTION
make-project will not work from command line (the .ros file) with this
check-type instruction. All necessary checks are done by
uiop:ensure-directory-pathname anyway.