### PR TITLE
add "asdf:" in front of "defsystem" to compile with no error

### DIFF
--- a/cl-project-test.asd
+++ b/cl-project-test.asd
@@ -3,7 +3,7 @@
   Copyright (c) 2011 Eitaro Fukamachi (e.arrows@gmail.com)
 |#
 
-(defsystem "cl-project-test"
+(asdf:defsystem "cl-project-test"
   :defsystem-depends-on ("prove-asdf")
   :author "Eitaro Fukamachi"
   :license "LLGPL"

--- a/cl-project.asd
+++ b/cl-project.asd
@@ -12,7 +12,7 @@
   Author: Eitaro Fukamachi (e.arrows@gmail.com)
 |#
 
-(defsystem "cl-project"
+(asdf:defsystem "cl-project"
   :version "0.3"
   :author "Eitaro Fukamachi"
   :license "LLGPL"

--- a/skeleton/skeleton-test.asd
+++ b/skeleton/skeleton-test.asd
@@ -5,7 +5,7 @@
 <%- @endif %>
 |#
 
-(defsystem "<% @var name %>-test"
+(asdf:defsystem "<% @var name %>-test"
   :defsystem-depends-on ("prove-asdf")
   :author "<% @var author %>"
   :license "<% @var license %>"

--- a/skeleton/skeleton.asd
+++ b/skeleton/skeleton.asd
@@ -19,7 +19,7 @@
 <%- @endif %>
 |#
 <% ) %>
-(defsystem "<% @var name %>"
+(asdf:defsystem "<% @var name %>"
   :version "0.1.0"
   :author "<% @var author %>"
   :license "<% @var license %>"


### PR DESCRIPTION
so that we can C-c C-c the defsystem with no error like before.

otherwise we get

> The function [first occurence of :depends-on] is undefined

It works back with

    (asdf:defsystem ...

or by adding back the lines that were suppressed in commit d5dc8861d749b5151995c0bbf81cd86dde9e4808 "use ASDF3 to be modern" one month ago.

This works back for me. Cheers, thanks for the stuff, please make some noise to promote CL21 :) (I try, and feeling alone)