### PR TITLE
I add nickname :clp in cl-project package

### DIFF
--- a/src/cl-project.lisp
+++ b/src/cl-project.lisp
@@ -1,6 +1,7 @@
 (in-package :cl-user)
 (defpackage cl-project
   (:use #:cl)
+  (:nicknames :clp)
   (:import-from #:cl-project.specials
                 #:*skeleton-directory*
                 #:*skeleton-parameters*)


### PR DESCRIPTION
It's too much bother to type "cl-project" every time.
So, I gave it short nickname "clp".

