### PR TITLE
Coerce string into pathname

### DIFF
--- a/roswell/make-project.ros
+++ b/roswell/make-project.ros
@@ -37,7 +37,7 @@ A command-line interface for cl-project:make-project.
     (let ((path (pop args)))
       (when (starts-with-subseq "--" path)
         (terminate "No path given."))
-      (cons path
+      (cons (pathname path)
             (loop for index from 0 below (length args)
                   for first = (elt args index)
                   for rest = (subseq args (incf index))


### PR DESCRIPTION
roswell script `make-project` doesn't work for `sbcl-bin/1.3.19` installed with roswell.

value of symbol `path` should be `PATHNAME`.

### stack trace

```
windymelt% make-project ./testproj --name testproj --author "windymelt"
Unhandled SIMPLE-TYPE-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                         {10019B7933}>:
  The value of CL-PROJECT::PATH is "./testproj", which is not of type PATHNAME.

Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {10019B7933}>
0: (SB-DEBUG::DEBUGGER-DISABLED-HOOK #<SIMPLE-TYPE-ERROR expected-type: PATHNAME datum: "./testproj"> #<unused argument>)
1: (SB-DEBUG::RUN-HOOK *INVOKE-DEBUGGER-HOOK* #<SIMPLE-TYPE-ERROR expected-type: PATHNAME datum: "./testproj">)
2: (INVOKE-DEBUGGER #<SIMPLE-TYPE-ERROR expected-type: PATHNAME datum: "./testproj">)
3: (ERROR #<SIMPLE-TYPE-ERROR expected-type: PATHNAME datum: "./testproj">)
4: (SB-KERNEL:WITH-SIMPLE-CONDITION-RESTARTS ERROR NIL #<SIMPLE-TYPE-ERROR expected-type: PATHNAME datum: "./testproj">)
5: (SB-KERNEL:CHECK-TYPE-ERROR CL-PROJECT::PATH "./testproj" PATHNAME NIL)
6: (CL-PROJECT:MAKE-PROJECT #<unavailable argument> :NAME "testproj" :AUTHOR "windymelt")
7: (SB-INT:SIMPLE-EVAL-IN-LEXENV (APPLY (QUOTE MAIN) ROSWELL:*ARGV*) #<NULL-LEXENV>)
8: (SB-INT:SIMPLE-EVAL-IN-LEXENV (ROSWELL:QUIT (APPLY (QUOTE MAIN) ROSWELL:*ARGV*)) #<NULL-LEXENV>)
9: (EVAL-TLF (ROSWELL:QUIT (APPLY (QUOTE MAIN) ROSWELL:*ARGV*)) NIL NIL)
10: ((LABELS SB-FASL::EVAL-FORM :IN SB-INT:LOAD-AS-SOURCE) (ROSWELL:QUIT (APPLY (QUOTE MAIN) ROSWELL:*ARGV*)) NIL)
11: (SB-INT:LOAD-AS-SOURCE #<CONCATENATED-STREAM :STREAMS NIL {100359CA23}> :VERBOSE NIL :PRINT NIL :CONTEXT "loading")
12: ((FLET SB-FASL::LOAD-STREAM :IN LOAD) #<CONCATENATED-STREAM :STREAMS NIL {100359CA23}> NIL)
13: (LOAD #<CONCATENATED-STREAM :STREAMS NIL {100359CA23}> :VERBOSE NIL :PRINT NIL :IF-DOES-NOT-EXIST T :EXTERNAL-FORMAT :DEFAULT)
14: ((FLET ROSWELL::BODY :IN ROSWELL:SCRIPT) #<SB-SYS:FD-STREAM for "file /home/windymelt/.roswell/bin/make-project" {1003597713}>)
15: (ROSWELL:SCRIPT "/home/windymelt/.roswell/bin/make-project" "./testproj" "--name" "testproj" "--author" "windymelt")
16: (ROSWELL:RUN ((:EVAL "(ros:quicklisp)") (:SCRIPT "/home/windymelt/.roswell/bin/make-project" "./testproj" "--name" "testproj" "--author" "windymelt") (:QUIT NIL)))
17: (SB-INT:SIMPLE-EVAL-IN-LEXENV (ROSWELL:RUN (QUOTE ((:EVAL "(ros:quicklisp)") (:SCRIPT "/home/windymelt/.roswell/bin/make-project" "./testproj" "--name" "testproj" "--author" "windymelt") (:QUIT NIL)))) #<NULL-LEXENV>)
18: (EVAL (ROSWELL:RUN (QUOTE ((:EVAL "(ros:quicklisp)") (:SCRIPT "/home/windymelt/.roswell/bin/make-project" "./testproj" "--name" "testproj" "--author" "windymelt") (:QUIT NIL)))))
19: (SB-IMPL::PROCESS-EVAL/LOAD-OPTIONS ((:EVAL . "(progn #-ros.init(cl:load \"/usr/local/etc/roswell/init.lisp\"))") (:EVAL . "(ros:run '((:eval\"(ros:quicklisp)\")(:script \"/home/windymelt/.roswell/bin/make-project\"\"./testproj\"\"--name\"\"testproj\"\"--author\"\"windymelt\")(:quit ())))")))
20: (SB-IMPL::TOPLEVEL-INIT)
21: ((FLET "WITHOUT-INTERRUPTS-BODY-10" :IN SAVE-LISP-AND-DIE))
22: ((LABELS SB-IMPL::RESTART-LISP :IN SAVE-LISP-AND-DIE))
```