### PR TITLE
divide .asd file into project and test

### DIFF
--- a/skeleton/skeleton-test.asd
+++ b/skeleton/skeleton-test.asd
@@ -1,0 +1,10 @@
+(defsystem "<% @var name %>/tests"
+  :author "<% @var author %>"
+  :license "<% @var license %>"
+  :depends-on ("<% @var name %>"
+               "rove")
+  :components ((:module "tests"
+                :components
+                ((:file "main"))))
+  :description "Test system for <% @var name %>"
+  :perform (test-op (op c) (symbol-call :rove :run c)))

--- a/skeleton/skeleton.asd
+++ b/skeleton/skeleton.asd
@@ -12,13 +12,3 @@
   :in-order-to ((test-op (test-op "<% @var name %>/tests")))
   <%- @endunless %>)
 
-(defsystem "<% @var name %>/tests"
-  :author "<% @var author %>"
-  :license "<% @var license %>"
-  :depends-on ("<% @var name %>"
-               "rove")
-  :components ((:module "tests"
-                :components
-                ((:file "main"))))
-  :description "Test system for <% @var name %>"
-  :perform (test-op (op c) (symbol-call :rove :run c)))


### PR DESCRIPTION
When I see OSS projects written in Common Lisp, it seems normal that .asd file is separated into project and test.
So, I rewrote skeleton file. 