### PR TITLE
Ignore *.abcl files from git

### DIFF
--- a/skeleton/.gitignore
+++ b/skeleton/.gitignore
@@ -1,3 +1,4 @@
+*.abcl
 *.fasl
 *.dx32fsl
 *.dx64fsl


### PR DESCRIPTION
Ignores ABCL Common Lisp generated bytecode file of off git.