### PR TITLE
Fix: without-tests

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -44,6 +44,7 @@ All parameters are optional.
 * `:email`: Your e-mail address.
 * `:license`: License of the new project.
 * `:depends-on`: A list of dependencies.
+* `:without-tests`: If true, then no testing system, folder, and file are generated. Default: nil.
 
 ## See Also
 - [Rove](https://github.com/fukamachi/rove) - Testing framework

--- a/skeleton/skeleton.asd
+++ b/skeleton/skeleton.asd
@@ -12,6 +12,7 @@
   :in-order-to ((test-op (test-op "<% @var name %>/tests")))
   <%- @endunless %>)
 
+<%- @unless without-tests %>
 (defsystem "<% @var name %>/tests"
   :author "<% @var author %>"
   :license "<% @var license %>"
@@ -22,3 +23,4 @@
                 ((:file "main"))))
   :description "Test system for <% @var name %>"
   :perform (test-op (op c) (symbol-call :rove :run c)))
+<%- @endunless %>

--- a/src/middleware.lisp
+++ b/src/middleware.lisp
@@ -9,7 +9,7 @@
 (defparameter *without-tests*
   (lambda (app &key
             (test-asd "skeleton-test.asd")
-            (test-directory #P"t/"))
+            (test-directory #P"tests/"))
     (lambda (file)
       (unless (or
                ;; Skip test ASD file


### PR DESCRIPTION
Now the `without-tests` parameter works as intended:
No testing system, folders or files is generated.

Also there is some information added in the README what effect the `without-tests` parameter exhibits.