### PR TITLE
Feature: add metadata parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,9 +7,18 @@
 
 ```common-lisp
 (cl-project:make-project #p"lib/cl-sample/"
+  :name "cl-sample"
+  :long-name "common-lisp-sample"
   :author "Eitaro Fukamachi"
+  :maintainer "Eitaro Fukamachi"
   :email "e.arrows@gmail.com"
   :license "LLGPL"
+  :homepage "https://github.com/fukamachi/cl-project"
+  :bug-tracker "https://github.com/fukamachi/cl-project/issues"
+  :source-control "https://github.com/fukamachi/cl-project.git"
+  :version "0.1.1"
+  :description "Sample library"
+  :long-description "Common Lisp sample library"
   :depends-on '(:clack :cl-annot))
 ;-> writing /Users/fukamachi/Programs/lib/cl-sample/.gitignore
 ;   writing /Users/fukamachi/Programs/lib/cl-sample/README.markdown
@@ -39,10 +48,17 @@ Modern projects should have some unit tests. CL-Project generates a system for u
 All parameters are optional.
 
 * `:name`: Project name. If this key isn't specified, the directory name will be used.
+* `:long-name`: Project name long form.
 * `:description`: Short description for the new project.
+* `:long-description`: Long description for the new project.
+* `:version`: Project version.
 * `:author`: Your name.
+* `:maintainer`: Project maintainer.
 * `:email`: Your e-mail address.
 * `:license`: License of the new project.
+* `:homepage`: Project homepage.
+* `:bug-tracker`: Project bug-tracker. E.g. Git issue tracker.
+* `:source-control`: Project source-control.
 * `:depends-on`: A list of dependencies.
 * `:without-tests`: If true, then no testing system, folder, and file are generated. Default: nil.
 

--- a/skeleton/skeleton.asd
+++ b/skeleton/skeleton.asd
@@ -1,13 +1,34 @@
 (defsystem "<% @var name %>"
-  :version "0.1.0"
+  <%- @if long-name %>
+  :long-name "<% @var long-name %>"
+  <%- @endif %>
+  :version "<% @var version %>"
   :author "<% @var author %>"
+  <%- @if maintainer %>
+  :maintainer "<% @var maintainer %>"
+  <%- @endif %>
+  <%- @if email %>
+  :mailto "<% @var email %>"
+  <%- @endif %>
   :license "<% @var license %>"
+  <%- @if homepage %>
+  :homepage "<% @var homepage %>"
+  <%- @endif %>
+  <%- @if bug-tracker %>
+  :bug-tracker "<% @var bug-tracker %>"
+  <%- @endif %>
+  <%- @if source-control %>
+  :source-control "<% @var source-control %>"
+  <%- @endif %>
   :depends-on (<% (format t "~{\"~(~A~)\"~^~%               ~}"
                           (getf env :depends-on)) %>)
   :components ((:module "src"
                 :components
                 ((:file "main"))))
   :description "<% @var description %>"
+  <%- @if long-description %>
+  :long-description "<% @var long-description %>"
+  <%- @endif %>
   <%- @unless without-tests %>
   :in-order-to ((test-op (test-op "<% @var name %>/tests")))
   <%- @endunless %>)

--- a/src/cl-project.lisp
+++ b/src/cl-project.lisp
@@ -13,9 +13,13 @@
            #:generate-skeleton))
 (in-package :cl-project)
 
-(defun make-project (path &rest params &key name description author email license depends-on (without-tests nil) &allow-other-keys)
+(defun make-project (path &rest params &key name long-name version description long-description
+                                         author maintainer email license homepage bug-tracker
+                                         source-control depends-on
+                                         (without-tests nil) &allow-other-keys)
   "Generate a skeleton."
-  (declare (ignore name description author email license depends-on without-tests))
+  (declare (ignore name long-name version description long-description author maintainer
+                   email license homepage bug-tracker source-control depends-on without-tests))
   (check-type path pathname)
 
   ;; Ensure `path' ends with a slash(/).


### PR DESCRIPTION
Add the following metadata parameter to make-project function (and docs):
`long-name` `version` `long-description` `maintainer` `homepage` `bug-tracker` `source-control`

Now a custom `version `can be supplied.
Additionally,`email` (if supplied) is used for `mailto` in the `.asd` file.