### PR TITLE
Feature: make-project verbose parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -61,6 +61,7 @@ All parameters are optional.
 * `:source-control`: Project source-control.
 * `:depends-on`: A list of dependencies.
 * `:without-tests`: If true, then no testing system, folder, and file are generated. Default: nil.
+* `:verbose`: If true, the written files directories are printed to the standard output. Default: t.
 
 ## See Also
 - [Rove](https://github.com/fukamachi/rove) - Testing framework

--- a/src/cl-project.lisp
+++ b/src/cl-project.lisp
@@ -16,7 +16,7 @@
 (defun make-project (path &rest params &key name long-name version description long-description
                                          author maintainer email license homepage bug-tracker
                                          source-control depends-on
-                                         (without-tests nil) &allow-other-keys)
+                                         (without-tests nil) (verbose t) &allow-other-keys)
   "Generate a skeleton."
   (declare (ignore name long-name version description long-description author maintainer
                    email license homepage bug-tracker source-control depends-on without-tests))
@@ -31,14 +31,16 @@
   (let ((files (generate-skeleton
                 *skeleton-directory*
                 path
-                :env params)))
+                :env params
+                :verbose verbose)))
     (dolist (file files)
       (when (string= (pathname-type file) "asd")
         (let ((dir (make-pathname :name nil :type nil :defaults file)))
           (push dir asdf:*central-registry*)))))
   t)
 
-(defun generate-skeleton (source-dir target-dir &key env)
+(defun generate-skeleton (source-dir target-dir &key env verbose)
   "General skeleton generator."
   (let ((*skeleton-parameters* env))
-    (generate (make-skeleton-from-directory source-dir) target-dir)))
+    (generate (make-skeleton-from-directory source-dir) target-dir
+              :verbose verbose)))

--- a/src/file.lisp
+++ b/src/file.lisp
@@ -20,8 +20,8 @@
 (defun make-template-file (path)
   (make-instance 'template-file :path path))
 
-(defgeneric generate (file target-dir)
-  (:method ((file template-file) target-dir)
+(defgeneric generate (file target-dir &key verbose)
+  (:method ((file template-file) target-dir &key verbose)
     (let ((target-path
             (merge-pathnames (template-file-path file) target-dir)))
       (when (search "skeleton" (pathname-name target-path))
@@ -33,5 +33,6 @@
                              :defaults target-path)))
       (copy-file-to-file (merge-pathnames (template-file-path file)
                                           *skeleton-directory*)
-                         target-path)
+                         target-path
+                         :verbose verbose)
       (list target-path))))

--- a/src/io.lisp
+++ b/src/io.lisp
@@ -7,9 +7,10 @@
   (:export #:copy-file-to-file))
 (in-package :cl-project.io)
 
-(defun copy-file-to-file (source-path target-path)
+(defun copy-file-to-file (source-path target-path &key verbose)
   "Copy a file `source-path` to the `target-path`."
-  (format t "~&writing ~A~%" target-path)
+  (when verbose
+    (format t "~&writing ~A~%" target-path))
   (ensure-directories-exist target-path)
   (with-open-file (stream target-path :direction :output :if-exists :supersede)
     (write-sequence

--- a/src/skeleton.lisp
+++ b/src/skeleton.lisp
@@ -23,9 +23,9 @@
 (defun make-skeleton (path children)
   (make-instance 'skeleton :path path :children children))
 
-(defmethod generate ((skeleton skeleton) target-dir)
+(defmethod generate ((skeleton skeleton) target-dir &key verbose)
   (let ((app (lambda (file)
-               (generate file target-dir))))
+               (generate file target-dir :verbose verbose))))
     (when (getf *skeleton-parameters* :without-tests)
       (setf app
             (funcall cl-project.middleware:*without-tests*


### PR DESCRIPTION
If the parameter `verbose` is `t` (default), the directories of the written files is printed to standard-output.

Now you can create projects without printing to the standard output, if verbose is set to `nil`.