### PR TITLE
Fix: add default version

### DIFF
--- a/skeleton/skeleton.asd
+++ b/skeleton/skeleton.asd
@@ -2,7 +2,11 @@
   <%- @if long-name %>
   :long-name "<% @var long-name %>"
   <%- @endif %>
+  <%- @if version %>
   :version "<% @var version %>"
+  <%- @else %>
+  :version "0.0.1"
+  <%- @endif %>
   :author "<% @var author %>"
   <%- @if maintainer %>
   :maintainer "<% @var maintainer %>"


### PR DESCRIPTION
Add default version (again) because empty version string results in warnings on multiple implementations.

Sorry for the inconvenience of another PR ...

I tried first to use default value of key parameter `(version "0.0.1")` but somehow that did not work out with the skeleton. 