### PR TITLE
Feat: Use uiop:define-package

### DIFF
--- a/skeleton/src/main.lisp
+++ b/skeleton/src/main.lisp
@@ -1,5 +1,5 @@
-(defpackage <% @var name %>
+(uiop:define-package <% @var name %>
   (:use :cl))
-(in-package :<% @var name %>)
+(in-package #:<% @var name %>)
 
 ;; blah blah blah.


### PR DESCRIPTION
`Uiop:define-package` supports more clauses:
`recycle`, `mix`, `reexport`, `use-reexport`, `mix-reexport`, `unintern`, `local-nicknames`. Additionally its easier in development when you remove a used package.

Also changed the `in-package` value from keyword to uninterned symbol.

Closes #43 