### PR TITLE
Feat: use, import-from, export clause

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,7 +19,10 @@
   :version "0.1.1"
   :description "Sample library"
   :long-description "Common Lisp sample library"
-  :depends-on '(:clack :cl-annot))
+  :depends-on '(:clack :cl-annot)
+  :use '(:alexandria)
+  :import-from '(:clack (:dexador :get :post))
+  :export '(:sample-symbol1 :symbol-2))
 ;-> writing /Users/fukamachi/Programs/lib/cl-sample/.gitignore
 ;   writing /Users/fukamachi/Programs/lib/cl-sample/README.markdown
 ;   writing /Users/fukamachi/Programs/lib/cl-sample/cl-sample-test.asd
@@ -59,9 +62,12 @@ All parameters are optional.
 * `:homepage`: Project homepage.
 * `:bug-tracker`: Project bug-tracker. E.g. Git issue tracker.
 * `:source-control`: Project source-control.
-* `:depends-on`: A list of dependencies.
+* `:depends-on`: A list of dependencies for the system definition. If `use` or `import-from` is specified, the respective packages are added to this list automatically.
 * `:without-tests`: If true, then no testing system, folder, and file are generated. Default: nil.
 * `:verbose`: If true, the written files directories are printed to the standard output. Default: t.
+* `:use`: A list of packages that will be in the use-clause of the package definition. If you do not want to use any package, then supply `nil`. Default value: `'(:cl)`.
+* `:import-from`: A list of packages and symbols that will be in import-from-clauses in the package definition. Value can be a list or nested list.
+* `:export`: A list of symbols that will be exported from the package definition.
 
 ## See Also
 - [Rove](https://github.com/fukamachi/rove) - Testing framework

--- a/skeleton/src/main.lisp
+++ b/skeleton/src/main.lisp
@@ -1,5 +1,25 @@
 (uiop:define-package <% @var name %>
-  (:use :cl))
+  <%- @if use %>
+  (:use<%(format t "~{ #:~(~A~)~^~}" (getf env :use)) %>)
+  <%- @endif %>
+  <%- @if import-from %>
+  <%=(with-output-to-string (s)
+       (let ((first-line t))
+	 (mapc #'(lambda (import-from-items)
+		   (if first-line
+		       (setf first-line nil)
+		       (format s "~%  "))
+		   (if (consp import-from-items)
+		       (format s "(:import-from~{ #:~(~A~)~^~%               ~})"
+			       import-from-items)
+		       (format s "(:import-from #:~(~A~))"
+			       import-from-items)))
+	       (getf env :import-from)))) %>
+  <%- @endif %>
+  <%- @if export %>
+  (:export <% (format t "~{#:~(~A~)~^~%           ~}"
+		      (getf env :export)) %>)
+  <%- @endif %>)
 (in-package #:<% @var name %>)
 
 ;; blah blah blah.


### PR DESCRIPTION
Now the `use`, `import-from`, and `export` clauses for the package definition can be specified during `make-project`.

If `use` or `import-from` is specified, the respective packages are added to `depends-on` in `.asd` automatically.

- `use`: A list of packages that will be in the use-clause of the package definition. Default value: `'(:cl)`.
- `import-from`: A list of packages and symbols that will be in import-from-clauses in the package definition. Value can be a list or nested list.
- `export`: A list of symbols that will be exported from the package definition.