### PR TITLE
Feat: Add code parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,16 +19,20 @@
   :version "0.1.1"
   :description "Sample library"
   :long-description "Common Lisp sample library"
-  :depends-on '(:clack :cl-annot)
-  :use '(:alexandria)
-  :import-from '(:clack (:dexador :get :post))
-  :export '(:sample-symbol1 :symbol-2))
+  :depends-on '(:clack alexandria)
+  :use '(:cl)
+  :import-from '(:clack (serapeum concat))
+  :export '(test-function test-constant)
+  :code '((alexandria:define-constant test-constant "hallo" :test 'string=)
+          (defun test-function (user)
+            "docstring"
+            (concat test-constant " " user))))
 ;-> writing /Users/fukamachi/Programs/lib/cl-sample/.gitignore
 ;   writing /Users/fukamachi/Programs/lib/cl-sample/README.markdown
 ;   writing /Users/fukamachi/Programs/lib/cl-sample/cl-sample-test.asd
 ;   writing /Users/fukamachi/Programs/lib/cl-sample/cl-sample.asd
-;   writing /Users/fukamachi/Programs/lib/cl-sample/src/hogehoge.lisp
-;   writing /Users/fukamachi/Programs/lib/cl-sample/t/hogehoge.lisp
+;   writing /Users/fukamachi/Programs/lib/cl-sample/src/main.lisp
+;   writing /Users/fukamachi/Programs/lib/cl-sample/t/main.lisp
 ;=> T
 ```
 
@@ -68,6 +72,7 @@ All parameters are optional.
 * `:use`: A list of packages that will be in the use-clause of the package definition. If you do not want to use any package, then supply `nil`. Default value: `'(:cl)`.
 * `:import-from`: A list of packages and symbols that will be in import-from-clauses in the package definition. Value can be a list or nested list.
 * `:export`: A list of symbols that will be exported from the package definition.
+* `:code`: Source code that will be inserted in main.lisp file. Can be nil, string, or a list of forms. Make sure to use, import-from, or qualify the necessary symbols.
 
 ## See Also
 - [Rove](https://github.com/fukamachi/rove) - Testing framework

--- a/skeleton/src/main.lisp
+++ b/skeleton/src/main.lisp
@@ -22,4 +22,4 @@
   <%- @endif %>)
 (in-package #:<% @var name %>)
 
-;; blah blah blah.
+<% @var code %>

--- a/src/cl-project.lisp
+++ b/src/cl-project.lisp
@@ -16,6 +16,7 @@
 (defun make-project (path &rest params &key name long-name version description long-description
                                          author maintainer email license homepage bug-tracker
                                          source-control depends-on (use nil use-p) import-from export
+					 (code nil code-p)
                                          (without-tests nil) (verbose t) &allow-other-keys)
   "Generate a skeleton."
   (declare (ignore name long-name version description long-description author maintainer
@@ -25,6 +26,13 @@
 
   ;; Ensure `path' ends with a slash(/).
   (setf path (uiop:ensure-directory-pathname path))
+  (if code-p
+      (when (consp code)
+	(setf (getf params :code)
+	      (let ((*print-case* :downcase))
+		(format nil "~{~S~%~}" code))))
+      (setf (getf params :code)
+	    ";; blah blah blah."))
   (unless use-p
     (setf (getf params :use)
 	  (list :cl)))


### PR DESCRIPTION
- If code is not supplied, the usual dummy comment will be inserted.
- If code is nil, no dummy comment will be inserted
- If code is a string, that string will be inserted.
- If code is a cons, that needs to be a list of forms. These forms will be converted with format to downcase string. Make sure to use/import-from the necessary symbols.

Finally we can generate a not-skeleton with source code ;)